### PR TITLE
Set back interface versions of mod-finc-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "hasSettings": true,
     "queryResource": "query",
     "okapiInterfaces": {
-      "metadata-sources": "1.0",
-      "metadata-collections": "1.0",
+      "metadata-sources": "0.1",
+      "metadata-collections": "0.1",
       "vendor": "1.0"
     },
     "permissionSets": [


### PR DESCRIPTION
mod-finc-config is not released until now, thus interfaces in v1.0 are not existent