### PR TITLE
Add buttonProps to find organization plugin

### DIFF
--- a/src/components/FindOrganization/FindOrganization.js
+++ b/src/components/FindOrganization/FindOrganization.js
@@ -77,12 +77,13 @@ class FindOrganization extends React.Component {
   render() {
     const disableRecordCreation = true;
     const vendorName = this.renderVendorName(this.state.vendor);
-
+    const buttonProps = { 'marginBottom0': true };
     const pluggable =
       <Pluggable
         aria-haspopup="true"
         type="find-organization"
         id="clickable-find-organization"
+        buttonProps={buttonProps}
         {...this.props}
         searchLabel="Organization look-up"
         marginTop0


### PR DESCRIPTION
This PR should fix the `ERROR:Cannot read property 'marginBottom0' of undefined` when creating a new metadata source