### PR TITLE
Bugfix: Use correct variable to call fetchMore()

### DIFF
--- a/src/routes/CollectionsRoute.js
+++ b/src/routes/CollectionsRoute.js
@@ -114,8 +114,8 @@ class CollectionsRoute extends React.Component {
   }
 
   handleNeedMoreData = () => {
-    if (this.source) {
-      this.source.fetchMore(RESULT_COUNT_INCREMENT);
+    if (this.collection) {
+      this.collection.fetchMore(RESULT_COUNT_INCREMENT);
     }
   };
 


### PR DESCRIPTION
This PR fixes the bug in the collections view of not loading more data when scrolling down.