### PR TITLE
Change CQL and add operator

### DIFF
--- a/src/components/MetadataCollections/filterConfigData.js
+++ b/src/components/MetadataCollections/filterConfigData.js
@@ -31,7 +31,8 @@ const filterConfig = [
   {
     label: 'Source',
     name: 'mdSource',
-    cql: 'mdSource',
+    cql: 'mdSource.id',
+    operator: '==',
     values: [],
   }
 ];


### PR DESCRIPTION
In order to estimate number of collections when using the mdSource filter we need to apply the '==' to use a b-tree index