### PR TITLE
UIFC-410: Migrate react-intl to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change history for ui-finc-config
 
-## [7.1.0] (IN PROGRESS)
+## [8.0.0] (IN PROGRESS)
 * Restructure SASQ and localStorage ([UIFC-400](https://folio-org.atlassian.net/browse/UIFC-400))
 * Add tests for SASQ, adapt renderWithIntlConfiguration ([UIFC-401](https://folio-org.atlassian.net/browse/UIFC-401))
 * Add rules for eslint ([UIFC-396](https://folio-org.atlassian.net/browse/UIFC-396))
 * Adapt tests for index.js and routes ([UIFC-402](https://folio-org.atlassian.net/browse/UIFC-402))
+* Migrate react-intl to v7 ([UIFC-410](https://folio-org.atlassian.net/browse/UIFC-410))
 
 ## [7.0.0](https://github.com/folio-org/ui-finc-config/tree/v7.0.0) (2024-11-04)
 * React v19: refactor away from default props for functional components([UIFC-355](https://folio-org.atlassian.net/browse/UIFC-355))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/finc-config",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Index configuration of finc catalogues",
   "main": "src/index.js",
   "repository": "folio-org/ui-finc-config",
@@ -12,7 +12,7 @@
     "test:jest": "jest --ci --coverage",
     "lint": "eslint src",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-finc-config ./translations/ui-finc-config/compiled"
+    "formatjs-compile": "stripes translate compile"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",
@@ -24,14 +24,13 @@
     "@folio/stripes-core": "^10.2.2",
     "@folio/stripes-final-form": "^8.1.0",
     "@folio/stripes-smart-components": "^9.2.2",
-    "@formatjs/cli": "^6.1.3",
     "eslint-plugin-canonical": "^4.0.0",
     "eslint-plugin-jest-dom": "^4.0.0",
     "eslint-plugin-testing-library": "^6.0.0",
     "history": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-query": "^3.9.0",
     "react-router-dom": "^5.2.0"
   },
@@ -50,7 +49,7 @@
     "@folio/stripes": "^9.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-query": "^3.9.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIFC-410

- update react-intl to v7
- remove @formatjs/cli; stripes-cli has it built-in

Refs [STRIPES-960](https://folio-org.atlassian.net/browse/STRIPES-960)