### PR TITLE
UIFC-493

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 * Use NoPermissionMessage from stripes-leipzig-components ([UIFC-475](https://folio-org.atlassian.net/browse/UIFC-475))
 * Integration of typescript ([UIFC-473](https://folio-org.atlassian.net/browse/UIFC-473))
+* Adapt TS configuration ([UIFC-493](https://folio-org.atlassian.net/browse/UIFC-493))
 
 ## [8.1.0](https://github.com/folio-org/ui-finc-config/tree/v8.1.0) (2026-04-20)
 * Support `finc-config-isils 2.0` interface ([UIFC-429](https://folio-org.atlassian.net/browse/UIFC-429))

--- a/src/components/MetadataCollections/CollectionFilters.tsx
+++ b/src/components/MetadataCollections/CollectionFilters.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
 import {

--- a/src/components/MetadataSources/SourceFilters.tsx
+++ b/src/components/MetadataSources/SourceFilters.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useIntl } from 'react-intl';
 
 import {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "checkJs": false,
     "esModuleInterop": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "lib": ["ES2020", "DOM"],
     "module": "ES2020",
     "moduleResolution": "node",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIFC-493

### Description

The build of the Testing-System causes errors:
```
ERROR in /etc/folio/stripes/node_modules/@folio/finc-config/src/components/MetadataSources/SourceFilters.tsx(89,10)
 TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.
```
```
ERROR in /etc/folio/stripes/node_modules/@folio/finc-config/src/components/MetadataCollections/CollectionFilters.tsx(90,10)
 TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.
```

Cause of these errors are differences in the `compilerOptions` in `tsconfig.json`:
**stripes-webpack** is using `"jsx": "react"`:
[stripes-webpack/webpack/tsconfig.json at aa1b4ca35d1be55cc4e4e96ff0d23ddacde3595e · folio-org/stripes-webpack](https://github.com/folio-org/stripes-webpack/blob/aa1b4ca35d1be55cc4e4e96ff0d23ddacde3595e/webpack/tsconfig.json#L5) 
**ui-finc-config** is using `"jsx": "react-jsx"`:

[ui-finc-config/tsconfig.json at 22909e56440ffb562883bf23270e3a2e0672c03b · folio-org/ui-finc-config](https://github.com/folio-org/ui-finc-config/blob/22909e56440ffb562883bf23270e3a2e0672c03b/tsconfig.json#L7) 
With this configuration in **ui-finc-config** is **no expliced import of React required**.
Since ui-finc-config is running wirhin a platform, the global configuration of` stripes-webpackare` decisive and the **import of React is required**.


**To fix this:**
- change configuration to `"jsx": "react"`
- add `import React from 'react';` to `SourceFilters.tsx `and `CollectionFilters.tsx`

→ The other differences `tsconfig.json` in  are more strict in `ui-finc-config` and can therefore remain as they are.